### PR TITLE
Added & to uninstall function to resolve php8 error

### DIFF
--- a/class.MentionerPlugin.php
+++ b/class.MentionerPlugin.php
@@ -459,7 +459,7 @@ class MentionerPlugin extends Plugin {
 	 *
 	 * @see Plugin::uninstall()
 	 */
-	function uninstall() {
+	function uninstall(&$errors) {
 		$errors = array ();
 		parent::uninstall ( $errors );
 	}


### PR DESCRIPTION
This should enable function with php 8.0 and OsTicket v1.16.

It might even work with v1.17 however it hasn't been tested.

There are known issues in other plugins with the changes for v1.17 so worth checking if settings are being read and working correctly.